### PR TITLE
Hide custom cell by subview (label) content

### DIFF
--- a/DynamicTableView/Controllers/ViewController.swift
+++ b/DynamicTableView/Controllers/ViewController.swift
@@ -12,9 +12,13 @@ class ViewController: UIViewController {
 
     @IBOutlet weak var tableView: UITableView!
     
-    var wordArray: [String] {
-        return "The quick brown fox jumps over the lazy dog".components(separatedBy: .whitespaces).map { $0 }
+    var wordArray = "The quick brown fox jumps over the lazy dog".components(separatedBy: .whitespaces).map { $0 } {
+        didSet {
+            tableView.reloadData()
+        }
     }
+    
+    var textIsHidden = false
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -39,11 +43,25 @@ extension ViewController: UITableViewDelegate, UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "DynamicTableViewCell", for: indexPath) as? DynamicTableViewCell else {
             fatalError("Fatal error: No cell")
         }
-        
+
         cell.wordLabel.text = wordArray[indexPath.row]
+        let hiddenWord = "lazy"
+        
+        cell.hideCellWith(word: hiddenWord)
+        if cell.isHidden == true {
+            wordArray.remove(at: indexPath.row)
+            let indexPath = IndexPath(index: indexPath.row)
+            tableView.deleteRows(at: [indexPath], with: .none)
+            textIsHidden = true
+        } else {
+            textIsHidden = false
+        }
+        
         return cell
     }
     
-    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return textIsHidden ? 0 : 50
+    }
 }
 

--- a/DynamicTableView/Controllers/ViewController.swift
+++ b/DynamicTableView/Controllers/ViewController.swift
@@ -49,10 +49,10 @@ extension ViewController: UITableViewDelegate, UITableViewDataSource {
         
         cell.hideCellWith(word: hiddenWord)
         if cell.isHidden == true {
+            textIsHidden = true
             wordArray.remove(at: indexPath.row)
             let indexPath = IndexPath(index: indexPath.row)
             tableView.deleteRows(at: [indexPath], with: .none)
-            textIsHidden = true
         } else {
             textIsHidden = false
         }

--- a/DynamicTableView/Views/DynamicTableViewCell.swift
+++ b/DynamicTableView/Views/DynamicTableViewCell.swift
@@ -12,4 +12,11 @@ class DynamicTableViewCell: UITableViewCell {
 
     @IBOutlet weak var wordLabel: UILabel!
     
+    func hideCellWith(word: String) {
+        if wordLabel.text == word {
+            isHidden = true
+        } else {
+            isHidden = false
+        }
+    }
 }

--- a/DynamicTableView/Views/DynamicTableViewCell.xib
+++ b/DynamicTableView/Views/DynamicTableViewCell.xib
@@ -19,18 +19,23 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s1G-GP-dn8">
-                        <rect key="frame" x="16" y="11" width="288" height="22"/>
-                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                        <color key="textColor" red="1" green="0.0" blue="0.5714479496" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ZjC-G7-IGz">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s1G-GP-dn8">
+                                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                <color key="textColor" red="1" green="0.0" blue="0.5714479496" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailingMargin" secondItem="s1G-GP-dn8" secondAttribute="trailing" id="And-bN-GaI"/>
-                    <constraint firstItem="s1G-GP-dn8" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="TwE-aA-FJH"/>
-                    <constraint firstItem="s1G-GP-dn8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="eww-Ml-SYV"/>
-                    <constraint firstItem="s1G-GP-dn8" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottomMargin" id="lJQ-Kf-FGa"/>
+                    <constraint firstItem="ZjC-G7-IGz" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="UhJ-AU-VHJ"/>
+                    <constraint firstAttribute="bottom" secondItem="ZjC-G7-IGz" secondAttribute="bottom" id="rFb-Eu-Ck2"/>
+                    <constraint firstItem="ZjC-G7-IGz" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="sjR-8U-CeM"/>
+                    <constraint firstAttribute="trailing" secondItem="ZjC-G7-IGz" secondAttribute="trailing" id="zS5-KF-Qfu"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>


### PR DESCRIPTION
## What does this PR do :question:
This PR demonstrates the method of hiding a tableview cells by the content of the custom cell's subview. In this case, the subview was a `UILabel`.

## How to test it :microscope:
1. Check out this branch
2. Run the app
3. Note that the cells display one word from the phrase `"The quick brown fox jumps over the lazy dog"`, with the word `lazy` removed (see screenshot below)

## Any background info you would like to include :white_check_mark:
Note that this method includes implementing the UITableView delegate method `heightForRowAt` to set the height of the hidden cell to 0. This solution sets the row height to 0 for all tableview cells without implementing this method. I would rather just delete the row according to `indexPath.row`, so I'll see what I can do about that!

## Screenshots (if applicable) :camera:
![Simulator Screen Shot - iPhone XR - 2019-03-14 at 11 03 46](https://user-images.githubusercontent.com/8409475/54367536-e845f800-4648-11e9-9308-4c242fbb4289.png)
